### PR TITLE
Fix yum php convergence

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,2 +1,2 @@
-site :opscode
+source 'https://supermarket.chef.io'
 metadata

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,6 @@
 default['webpagetest-web']['documentroot'] = "/var/www"
+
+apache_modules = node['apache']['default_modules']
+if !apache_modules.include?('php5')
+  default['apache']['default_modules'] << 'php5'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,10 @@ description      'Installs/Configures webpagetest web-server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
-depends 'yum'
-depends 'git'
-depends 'apache2'
-depends 'php'
+depends 'yum-repoforge', '~> 0.5.0'
+depends 'git', '~> 4.1.0'
+depends 'apache2', '~> 3.0.1'
+depends 'php', '~> 1.5.0'
 
 %w{ centos }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,7 +10,7 @@
 documentroot = "#{node['webpagetest-web']['documentroot']}/webpagetest"
 
 # yum
-include_recipe 'yum::repoforge'
+include_recipe 'yum-repoforge'
 include_recipe 'build-essential'
 include_recipe 'git'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook Name:: webpagetest-web
+# spec:: spec_helper
+#
+
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'webpagetest-web::default' do
+  context 'When all attributes are default' do
+
+    cached(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4')
+      runner.converge(described_recipe)
+    end
+
+    before do
+      stub_command("/usr/sbin/apache2 -t").and_return(true)
+      stub_command("which php").and_return('/usr/bin/php')
+      stub_command("/usr/sbin/httpd -t").and_return(true)
+    end
+
+    it 'converges successfully' do
+      chef_run
+    end
+
+    it 'should include yum-repoforge recipe' do
+      expect(chef_run).to include_recipe('yum-repoforge')
+    end
+
+    it 'should include apache2::mod_php5 recipe' do
+      expect(chef_run).to include_recipe('apache2::mod_php5')
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes 2 problems:
- The cookbook doesn't converge because yum::repoforge recipe no longer exists.
- Plaintext PHP is served by Apache

I restored repoforge by using https://github.com/chef-cookbooks/yum-repoforge, updated the default attributes to ensure the apache2 cookbook installs mod_php5, locked the metadata dependency versions, and wrote tests for these changes.
